### PR TITLE
Add Headphones PIDfile and webserver shutdown

### DIFF
--- a/FreeBSD/Headphones/headphones
+++ b/FreeBSD/Headphones/headphones
@@ -29,16 +29,31 @@ rcvar=${name}_enable
 load_rc_config ${name}
 
 : ${headphones_enable:="NO"}
-: ${headphones_user:="USERNAME"}
+: ${headphones_user:="_sabnzbd"}
 : ${headphones_dir:="/usr/local/headphones"}
 : ${headphones_chdir:="${headphones_dir}"}
 : ${headphones_pid:="${headphones_dir}/headphones.pid"}
+: ${headphones_conf:="${headphones_dir}/config.ini"}
+pidfile="${headphones_dir}/headphones.pid"
+
+WGET="/usr/local/bin/wget" # You need wget for this script to safely shutdown Headphones.
+if [ -e "${headphones_conf}" ]; then
+        HOST=`grep -A14 "\[General\]" "${headphones_conf}"|egrep "^http_host"|perl -wple 's/^http_host = (.*)$/$1/'`
+        PORT=`grep -A14 "\[General\]" "${headphones_conf}"|egrep "^http_port"|perl -wple 's/^http_port = (.*)$/$1/'`
+        HPAPI=`grep -A14 "\[General\]" "${headphones_conf}"|egrep "^api_key"|perl -wple 's/^api_key = (.*)$/$1/'`
+fi
 
 status_cmd="${name}_status"
 stop_cmd="${name}_stop"
 
 command="/usr/sbin/daemon"
 command_args="-f -p ${headphones_pid} python ${headphones_dir}/Headphones.py ${headphones_flags} --quiet"
+
+# Check for wget and refuse to start without it.
+if [ ! -x "${WGET}" ]; then
+  warn "couchpotato not started: You need wget to safely shut down Headphones."
+  exit 1
+fi
 
 # Ensure user is root when running this script.
 if [ `id -u` != "0" ]; then
@@ -55,8 +70,13 @@ verify_headphones_pid() {
 
 # Try to stop Headphones cleanly by calling shutdown over http.
 headphones_stop() {
+    if [ ! -e "${headphones_conf}" ]; then
+        echo "Headphones' settings file does not exist. Try starting Headphones, as this should create the file."
+        exit 1
+    fi
     echo "Stopping $name"
     verify_headphones_pid
+    ${WGET} -O - -q "http://${HOST}:${PORT}/api?apikey=${HPAPI}&cmd=shutdown" >/dev/null
     if [ -n "${pid}" ]; then
       wait_for_pids ${pid}
       echo "Stopped"


### PR DESCRIPTION
Added pidfile line to avoid "Headphones already running? (pid=xxxx)" error
Added WGET functionality to shutdown the server with an APIkey, HOST and PORT.
Based on the original Couchpotato startup file.
